### PR TITLE
Update policies based on feedback from Student Privacy Pledge

### DIFF
--- a/faqs.md
+++ b/faqs.md
@@ -50,16 +50,16 @@ A. The Family Education Rights and Privacy Act (FERPA), is a federal law that pr
 Unlike COPPA, which applies to all online operators, FERPA regulates an educational institution’s use of student data.
 Here is how our product policies can help those institutions meet their obligations under FERPA.
 
-We do not intend for any students to use **teacher.desmos.com**, so FERPA isn't a consideration there.
+We expect teachers, not students, to use **teacher.desmos.com** for creating and running activities, so FERPA isn't a consideration for work done on that website.
 
 Our **Desmos Tools** are intended for individual usage.
 We don’t know when any of these tools is used at the direction of a teacher as part of an assignment, so we can’t be helpful with FERPA compliance.
-For this reason, we strongly recommend that teachers and schools only use teacher.desmos.com and student.desmos.com for academic assignments.
+For this reason, we strongly recommend that teachers and schools only use teacher.desmos.com and student.desmos.com for collecting academic assignments.
 
 We assume that all work in **student.desmos.com** has been assigned by a teacher or school for academic purposes.
 We don’t own any personal information collected through student.desmos.com &ndash; that work is owned by the teacher and school. Parents and students have rights under FERPA to access that work.
-Note that if an account is deleted by a student, work done on student.desmos.com will not necessarily be deleted!
-Only a teacher or school can ask us to delete a student's work.
+Note that only a teacher or school can ask Desmos to delete work done on student.desmos.com.
+Note further that if an account on teacher.desmos.com is deleted, student work associated with any activities that the teacher ran will be deleted as a result, even for students who still have an account.
 Please see our [Student Data Privacy Statement](//www.desmos.com/studentdata) for more details.
 
 
@@ -89,7 +89,7 @@ However, you can subscribe to notifications from the github repository if you’
 
 These FAQs were last updated April 25, 2017.
 
-## What if I have other questions?
+## Q. What if I have other questions?
 
 A. If you have any questions about any of our policies, just send us an e-mail at [support@desmos.com](mailto:support@desmos.com).
 

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -106,7 +106,7 @@ We may not be able to modify or delete your information in all circumstances.
 We care about the security of your information and employ physical, administrative, and technological safeguards designed to preserve the integrity and security of all information collected through our Service.
 Access to information is limited (through user/password credentials and, in some cases, two factor authentication) to those employees who require it to perform their job functions.
 We use industry standard SSL (secure socket layer technology) encryption to transfer personal information.
-Other security safeguards include but are not limited to data encryption, firewalls, and physical access controls to buildings and files.
+Other security safeguards include but are not limited to data encryption, firewalls, physical access controls to buildings and files, and employee training.
 You can help protect against unauthorized access to your account and personal information by selecting and protecting your password appropriately and limiting access to your computer and browser by signing off after you have finished accessing your account.
 
 <h2 id="childrens-privacy">6. Children’s Privacy</h2>

--- a/student-data-privacy-statement.md
+++ b/student-data-privacy-statement.md
@@ -18,12 +18,14 @@ We are honored that our School customers choose Desmos as a trusted educational 
 When we have access to the personal information of students, we commit to the following data privacy principles:
 
 * Desmos collects, stores, processes, and shares Student Data only for the purposes of providing our Service, or as authorized by a school or a parent.
-* Desmos does not sell, use, or share Student Data or content for marketing or advertising purposes, except with explicit school or parental consent.
-* Desmos does not use Student Data for targeted advertising purposes.
+* Desmos does not use or share Student Data or content for marketing or advertising purposes, except with explicit school or parental consent.
+* Desmos does not sell Student Data.
+* Desmos does not use or disclose Student Data for targeted advertising purposes.
 * Desmos will maintain a comprehensive data security program designed to protect the types of Student Data maintained by Desmos.
+* Desmos will not knowingly retain Student Data beyond the time period required to support the school’s purpose, unless authorized by the parent/student.
 * Desmos will delete or de-identify Student Data at the direction or request of the school.
 * Desmos will clearly and transparently disclose our data policies and practices.
-* Desmos will not make any material changes to our Privacy Policy or Terms of Service that relate to the collection or use of Student Data without first giving notice to the school or parent and providing a choice before the Student Data is used in a materially different manner than was disclosed when the information was collected.
+* Desmos will not make any material changes to our [Privacy Policy](/privacy) or [Terms of Service](/terms) that relate to the collection or use of Student Data without first giving notice to the school or parent and providing a choice before the Student Data is used in a materially different manner than was disclosed when the information was collected.
 
 If you have any questions, please contact us at [support@desmos.com](mailto:support@desmos.com)
 

--- a/terms-of-service.md
+++ b/terms-of-service.md
@@ -59,7 +59,7 @@ As between the parties, the School or the Student owns and controls the Student 
 
 *Personal Information and Student Data Consents and Authority*.
 If you are School User, you represent and warrant that you have provided appropriate disclosures to your School and to parents regarding your sharing such Personal Information with Desmos.
-Both Parties agree to uphold their obligations under the Family Educational Rights and Privacy Act (“FERPA”), the Protection of Pupil Rights Amendment ("PPRA"), and the Children’s Online Privacy and Protection Act (“COPPA”) and applicable State laws.
+Both Parties agree to uphold their obligations under the Family Educational Rights and Privacy Act (“FERPA”), the Protection of Pupil Rights Amendment ("PPRA"), and the Children’s Online Privacy and Protection Act (“COPPA”) and applicable State laws relating to student data privacy.
 Desmos relies on each School to obtain and provide appropriate consent and disclosures, if necessary, for Desmos to collect any Student Data, including the collection of Student Data directly from students under 13, as permitted under COPPA.
 We recommend that you provide a copy of the Desmos [Student Data Privacy Statement](/studentdata) to Parents.
 You agree to comply with these Terms and all laws and regulations governing the protection of personal information, including children’s information, and the sharing of student education records.
@@ -82,6 +82,7 @@ We and our employees, affiliates, service providers, or agents involved in the h
 *Student Data Retention and Deletion Requests*.
 Schools may request that we delete Student Data in our possession at any time by providing such a request in writing, except that Desmos shall not be required to delete content a Student shared to public areas of the Service.
 We shall respond to the deletion request as soon as possible, but in most instances within 45 days, other than for data stored on backup tapes which shall be deleted in the ordinary course of business.
+For inactive accounts, we delete or de-identify Student Data in our possession after a period of dormancy or at the request of a Parent.
 A Parent seeking to modify, correct, or delete personal information in a Student Account that is connected to an active School account will be instructed to contact the School to discuss data deletion or modification.
 We are not required to delete data that has been derived from Student Data so long as it has been anonymized such that it does not reasonably identify an individual.
 Similarly, we are not required to delete information which a Student or parent has saved or transferred to a personal account.


### PR DESCRIPTION
* Clarify that we _never_ sell Student Data
* Clarify that we do not knowingly retain student data beyond its academic utility
* Clarify that we delete Student Data when the associated teacher/school account is deleted
* Add a missing "Q"
* Clarify why FERPA doesn't apply to work on teacher.desmos.com