### PR TITLE
Fix a formatting issue with markdown / HTML and correct incorrect link

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -206,9 +206,9 @@ Additionally, as required by GDPR, Desmos has SCCs with our subcontractors who p
 
 <h2 id="changes-and-updates">12. Changes and Updates</h2>
 
-<div class="summary-highlight">**Summary**: We will update this policy as necessary, and you can see the history of such changes [here](https://github.com/desmosinc/policies).</div>
+<div class="summary-highlight"><strong>Summary</strong>: We will update this policy as necessary, and you can see the history of such changes <a href="https://github.com/desmosinc/policies">here</a>.</div>
 
 a. _Updates_.
-This Privacy Policy may be revised periodically and this will be reflected in the “date last modified” set forth below. Your continued use of the Desmos Services following such an update constitutes your agreement to the revised Privacy Policy. You can see the history of the changes to this Privacy Policy [here](/privacy).
+This Privacy Policy may be revised periodically and this will be reflected in the “date last modified” set forth below. Your continued use of the Desmos Services following such an update constitutes your agreement to the revised Privacy Policy. You can see the history of the changes to this Privacy Policy [here]([/privacy](https://github.com/desmosinc/policies)).
 
 b. _Last Modified_. This Privacy Policy was last modified on September 1, 2023.


### PR DESCRIPTION
While reading the policy I noticed there was an issue where Markdown styling inside of a div for a summary was not being rendered on the website and also on Github. This PR fixes the issue by using HTML styling within said div.

Additionally, it corrects what I presume to be an incorrect link as the summary of Section 12 (Changes and Updates) references this Github repository as the place to view a history of the document but the actual section body references the privacy policy on desmos.com (desmos.com/privacy) which does not have a way to view past revisions. I corrected the link to point to the Github repo as the summary does.

I did not update the last updated date as I was not sure if a minor formatting fix counted as a significant modification, but if Desmos thinks it should be incremented that is fine.